### PR TITLE
Accelerate with copilot

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -109,3 +109,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"{email} inscrito(a) em {activity_name} com sucesso"}
+
+
+@app.delete("/activities/{activity_name}/participants/{email}")
+def remove_participant(activity_name: str, email: str):
+    """Remove a participant from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Atividade não encontrada")
+        
+    # Get the specific activity
+    activity = activities[activity_name]
+    
+    # Check if participant is in the activity
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail=f"{email} não está inscrito(a) em {activity_name}")
+    
+    # Remove participant
+    activity["participants"].remove(email)
+    return {"message": f"{email} removido(a) de {activity_name} com sucesso"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
       "schedule": "Segundas, quartas e sextas, 14h - 15h",
       "max_participants": 30,
       "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+   },
+   # Esportivas
+   "Futebol": {
+      "description": "Participe do time de futebol da escola e jogue campeonatos",
+      "schedule": "Terças e quintas, 16h30 - 18h",
+      "max_participants": 22,
+      "participants": ["lucas@mergington.edu", "marcos@mergington.edu"]
+   },
+   "Vôlei": {
+      "description": "Treinos e partidas de vôlei para todos os níveis",
+      "schedule": "Quartas e sextas, 17h - 18h30",
+      "max_participants": 18,
+      "participants": ["ana@mergington.edu", "carla@mergington.edu"]
+   },
+   # Artísticas
+   "Teatro": {
+      "description": "Aulas de interpretação e produção de peças teatrais",
+      "schedule": "Segundas e quartas, 16h - 17h30",
+      "max_participants": 15,
+      "participants": ["bruno@mergington.edu", "lara@mergington.edu"]
+   },
+   "Oficina de Pintura": {
+      "description": "Desenvolva suas habilidades artísticas com pintura em tela",
+      "schedule": "Sábados, 10h - 12h",
+      "max_participants": 10,
+      "participants": ["juliana@mergington.edu", "rafael@mergington.edu"]
+   },
+   # Intelectuais
+   "Clube de Leitura": {
+      "description": "Leitura e discussão de livros clássicos e contemporâneos",
+      "schedule": "Quartas, 15h - 16h",
+      "max_participants": 16,
+      "participants": ["paula@mergington.edu", "gustavo@mergington.edu"]
+   },
+   "Olimpíada de Matemática": {
+      "description": "Preparação para olimpíadas de matemática e desafios lógicos",
+      "schedule": "Sextas, 14h - 15h30",
+      "max_participants": 25,
+      "participants": ["aline@mergington.edu", "pedro@mergington.edu"]
    }
 }
 
@@ -61,6 +100,11 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specificy activity
     activity = activities[activity_name]
+
+    # Validar se o estudante já está inscrito
+    if email in activity["participants"]:
+       raise HTTPException(status_code=400, detail=f"{email} já está inscrito(a) em {activity_name}")
+
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -142,3 +142,50 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+/* Estilos para a seção de participantes */
+.participants-section {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #f8f9fa;
+  border-radius: 5px;
+  border-left: 3px solid #0366d6;
+}
+
+.participants-section h5 {
+  color: #24292e;
+  margin-bottom: 8px;
+  font-size: 16px;
+}
+
+.participants-list {
+  list-style-type: none;
+  padding-left: 10px;
+  margin: 0;
+}
+
+.participants-list li {
+  padding: 3px 0;
+  color: #586069;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.delete-icon {
+  color: #cb2431;
+  cursor: pointer;
+  font-size: 14px;
+  margin-left: 8px;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+}
+
+.delete-icon:hover {
+  opacity: 1;
+}
+
+.participants-section em {
+  color: #6a737d;
+  font-style: italic;
+}


### PR DESCRIPTION
This pull request introduces several enhancements to the activity management system, including new activities, participant management functionality, and UI improvements. The most important changes focus on expanding the activities dataset, adding backend support for participant removal, and updating the frontend to display participants and enable their removal.

### Backend Updates:
* Added new activities categorized as "Esportivas," "Artísticas," and "Intelectuais" with details such as description, schedule, maximum participants, and initial participants. (`src/app.py`, [src/app.pyR41-R79](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R41-R79))
* Implemented a new endpoint `remove_participant` to allow removing participants from activities, including validation checks for activity existence and participant enrollment. (`src/app.py`, [src/app.pyR104-R130](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R104-R130))

### Frontend Updates:
* Updated activity cards to include a "Participants" section, displaying a list of enrolled participants or a message if none are enrolled. (`src/static/app.js`, [src/static/app.jsR28-R40](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R28-R40))
* Added functionality to refresh the activities list after participant signup to reflect changes dynamically. (`src/static/app.js`, [src/static/app.jsR78-R79](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R78-R79))
* Implemented participant removal functionality in the UI, including a confirmation dialog and error handling for failed removal attempts. (`src/static/app.js`, [src/static/app.jsR99-R192](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R99-R192))

### Styling Enhancements:
* Added CSS styles for the "Participants" section, including layout, colors, and hover effects for the delete icon. (`src/static/styles.css`, [src/static/styles.cssR145-R191](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R145-R191))